### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ A VS Code extension that brings spec-driven development to Codex CLI, leveraging
 Search for "Kiro for Codex IDE" in the VS Code Marketplace and install the extension.
 
 ### From Local VSIX
-1. Build the package with `npm run package` (produces `kiro-for-codex-ide-ide-<version>.vsix`).
-2. Install via `code --install-extension kiro-for-codex-ide-ide-<version>.vsix`.
+1. Build the package with `npm run package` (produces `kiro-for-codex-ide-<version>.vsix`).
+2. Install via `code --install-extension kiro-for-codex-ide-<version>.vsix`.
 
 ## Usage
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified local VSIX installation instructions by correcting the package filename, removing the redundant “-ide” suffix (now kiro-for-codex-ide-<version>.vsix).
  * Updated the install command example to use the corrected filename.
  * Made a minor formatting tweak to the “Original project” reference, affecting presentation only and not functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->