### PR TITLE
Add custom steering creation dialog with autosave support

### DIFF
--- a/.codex/prompts/generate-pull-request-draft.md
+++ b/.codex/prompts/generate-pull-request-draft.md
@@ -1,25 +1,36 @@
-# Generate Pull Request Title and Description from Git Diff and Commits
+# Generate Pull Request Title and Description (Interactive Workflow)
 
 You are a member of a software development team.
-Your task is to create a **clear, concise, and professional Pull Request (PR) title and description**.
-
-* **Target branch:** `main`
-* Review the **diff and commit history** compared to the `main` branch and summarize the changes.
+Your task is to create a **clear, concise, and professional Pull Request (PR) title and description** — step by step, with user confirmation at each stage.
 
 ---
 
-## Output Requirements
+## Workflow Steps
 
-1. **Generate both a PR title and PR body.**
-2. **Write the PR message to `.tmp/pull-request-message-draft.md`.**
+### **Step 1 — Confirm Target Branch**
 
-   * If the file already exists, **completely clear its contents before writing**.
-   * Save the file in **UTF-8 (LF)** encoding.
-3. Follow the template below for the PR body.
+Ask the user which branch the PR will be merged **into** (target branch).
+If the user does not specify, suggest `main` as the default.
+
+> Example:
+> “Which branch should this PR target? (default: main)”
 
 ---
 
-## Output Template
+### **Step 2 — Generate Draft PR Message**
+
+Once the target branch is confirmed:
+
+1. Review the **git diff** and **commit history** compared to the confirmed target branch.
+2. Generate both a **PR title** and **PR body draft**.
+3. Write the draft message to `.tmp/pull-request-message-draft.md`.
+
+**File Rules:**
+
+* If the file already exists, **clear its contents completely before writing**.
+* Save the file in **UTF-8 (LF)** encoding.
+
+Use the following **template** for the draft:
 
 ```
 # Pull Request Message (Draft)
@@ -39,10 +50,34 @@ Briefly summarize what changes this PR introduces.
 
 ---
 
-## Generation Instructions
+### **Step 3 — Ask for User Review**
 
-1. Use the **commit messages and diff details** to summarize the “Changes” section accurately.
-2. Write the content in **English**, maintaining a **professional and business-appropriate tone**.
-3. The PR title should be **concise (≤ 80 characters)** and summarize the main intent of the change.
-4. If possible, include hints about affected components, features, or fixes in the title (e.g., “Fix build script error in CI pipeline”).
-5. Ensure the output file `.tmp/pull-request-message-draft.md` contains **only the new generated message**, with no leftover content.
+After generating the draft file, show a short preview and ask:
+
+> “Please review the draft in `.tmp/pull-request-message-draft.md`.
+> Would you like to revise it, or proceed to create the Pull Request?”
+
+If the user requests changes, regenerate the draft accordingly.
+
+---
+
+### **Step 4 — Create the Pull Request**
+
+When the user approves the draft:
+
+* Run the following command to create the Pull Request automatically using GitHub CLI:
+
+```
+gh pr create --fill --title "<generated title>" --body-file .tmp/pull-request-message-draft.md --base <target branch>
+```
+
+Confirm successful creation, and display the resulting PR link.
+
+---
+
+## Additional Requirements
+
+1. All text must be written in **English**, with a **professional and business-appropriate tone**.
+2. The PR title should be **≤ 80 characters**, summarizing the intent clearly (e.g., “Add autosave logic to CreateSpec controller”).
+3. Include hints about the **affected components, features, or fixes** when possible.
+4. Ensure the output file `.tmp/pull-request-message-draft.md` contains **only the new generated message**, with no leftover content.

--- a/.codex/prompts/generate-pull-request-draft.md
+++ b/.codex/prompts/generate-pull-request-draft.md
@@ -33,13 +33,6 @@ Once the target branch is confirmed:
 Use the following **template** for the draft:
 
 ```
-# Pull Request Message (Draft)
-
-## Title
-<Write the PR title here>
-
-## Body
-
 ### Overview
 Briefly summarize what changes this PR introduces.
 

--- a/.codex/prompts/openspec-create-change-proposal.md
+++ b/.codex/prompts/openspec-create-change-proposal.md
@@ -1,0 +1,19 @@
+# openspec-create-change-proposal
+
+You are an assistant that helps users create **OpenSpec change proposals** for new features.
+
+## Instructions
+
+1. **Confirm the Feature**
+
+   * Before starting, ask the user to describe the feature they want to add in detail.
+   * Clarify its purpose, scope, and any relevant context (e.g., related specs, modules, or dependencies).
+   * Example questions:
+
+     * “What feature would you like to add?”
+     * “Could you explain how this feature fits into the current system?”
+     * “Are there any related components or constraints I should be aware of?”
+
+2. **Create the OpenSpec Change Proposal**
+
+   * Once the feature is confirmed, create an OpenSpec change proposal for this feature.

--- a/.codex/prompts/openspec-populate-prject-context.md
+++ b/.codex/prompts/openspec-populate-prject-context.md
@@ -1,0 +1,3 @@
+# openspec-populate-prject-context
+
+Please read openspec/project.md and help me fill it out with details about my project, tech stack, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,22 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->
+
 # AGENTS Contract
 
 ## Steering Documents

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,454 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## TL;DR Quick Checklist
+
+- Search existing work: `openspec spec list --long`, `openspec list` (use `rg` only for full-text search)
+- Decide scope: new capability vs modify existing capability
+- Pick a unique `change-id`: kebab-case, verb-led (`add-`, `update-`, `remove-`, `refactor-`)
+- Scaffold: `proposal.md`, `tasks.md`, `design.md` (only if needed), and delta specs per affected capability
+- Write deltas: use `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`; include at least one `#### Scenario:` per requirement
+- Validate: `openspec validate [change-id] --strict` and fix issues
+- Request approval: Do not start implementation until proposal is approved
+
+## Three-Stage Workflow
+
+### Stage 1: Creating Changes
+Create proposal when you need to:
+- Add features or functionality
+- Make breaking changes (API, schema)
+- Change architecture or patterns  
+- Optimize performance (changes behavior)
+- Update security patterns
+
+Triggers (examples):
+- "Help me create a change proposal"
+- "Help me plan a change"
+- "Help me create a proposal"
+- "I want to create a spec proposal"
+- "I want to create a spec"
+
+Loose matching guidance:
+- Contains one of: `proposal`, `change`, `spec`
+- With one of: `create`, `plan`, `make`, `start`, `help`
+
+Skip proposal for:
+- Bug fixes (restore intended behavior)
+- Typos, formatting, comments
+- Dependency updates (non-breaking)
+- Configuration changes
+- Tests for existing behavior
+
+**Workflow**
+1. Review `openspec/project.md`, `openspec list`, and `openspec list --specs` to understand current context.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, optional `design.md`, and spec deltas under `openspec/changes/<id>/`.
+3. Draft spec deltas using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement.
+4. Run `openspec validate <id> --strict` and resolve any issues before sharing the proposal.
+
+### Stage 2: Implementing Changes
+Track these steps as TODOs and complete them one by one.
+1. **Read proposal.md** - Understand what's being built
+2. **Read design.md** (if exists) - Review technical decisions
+3. **Read tasks.md** - Get implementation checklist
+4. **Implement tasks sequentially** - Complete in order
+5. **Confirm completion** - Ensure every item in `tasks.md` is finished before updating statuses
+6. **Update checklist** - After all work is done, set every task to `- [x]` so the list reflects reality
+7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
+
+### Stage 3: Archiving Changes
+After deployment, create separate PR to:
+- Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
+- Update `specs/` if capabilities changed
+- Use `openspec archive <change-id> --skip-specs --yes` for tooling-only changes (always pass the change ID explicitly)
+- Run `openspec validate --strict` to confirm the archived change passes checks
+
+## Before Any Task
+
+**Context Checklist:**
+- [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] Check pending changes in `changes/` for conflicts
+- [ ] Read `openspec/project.md` for conventions
+- [ ] Run `openspec list` to see active changes
+- [ ] Run `openspec list --specs` to see existing capabilities
+
+**Before Creating Specs:**
+- Always check if capability already exists
+- Prefer modifying existing specs over creating duplicates
+- Use `openspec show [spec]` to review current state
+- If request is ambiguous, ask 1–2 clarifying questions before scaffolding
+
+### Search Guidance
+- Enumerate specs: `openspec spec list --long` (or `--json` for scripts)
+- Enumerate changes: `openspec list` (or `openspec change list --json` - deprecated but available)
+- Show details:
+  - Spec: `openspec show <spec-id> --type spec` (use `--json` for filters)
+  - Change: `openspec show <change-id> --json --deltas-only`
+- Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" openspec/specs`
+
+## Quick Start
+
+### CLI Commands
+
+```bash
+# Essential commands
+openspec list                  # List active changes
+openspec list --specs          # List specifications
+openspec show [item]           # Display change or spec
+openspec validate [item]       # Validate changes or specs
+openspec archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
+
+# Project management
+openspec init [path]           # Initialize OpenSpec
+openspec update [path]         # Update instruction files
+
+# Interactive mode
+openspec show                  # Prompts for selection
+openspec validate              # Bulk validation mode
+
+# Debugging
+openspec show [change] --json --deltas-only
+openspec validate [change] --strict
+```
+
+### Command Flags
+
+- `--json` - Machine-readable output
+- `--type change|spec` - Disambiguate items
+- `--strict` - Comprehensive validation
+- `--no-interactive` - Disable prompts
+- `--skip-specs` - Archive without spec updates
+- `--yes`/`-y` - Skip confirmation prompts (non-interactive archive)
+
+## Directory Structure
+
+```
+openspec/
+├── project.md              # Project conventions
+├── specs/                  # Current truth - what IS built
+│   └── [capability]/       # Single focused capability
+│       ├── spec.md         # Requirements and scenarios
+│       └── design.md       # Technical patterns
+├── changes/                # Proposals - what SHOULD change
+│   ├── [change-name]/
+│   │   ├── proposal.md     # Why, what, impact
+│   │   ├── tasks.md        # Implementation checklist
+│   │   ├── design.md       # Technical decisions (optional; see criteria)
+│   │   └── specs/          # Delta changes
+│   │       └── [capability]/
+│   │           └── spec.md # ADDED/MODIFIED/REMOVED
+│   └── archive/            # Completed changes
+```
+
+## Creating Change Proposals
+
+### Decision Tree
+
+```
+New request?
+├─ Bug fix restoring spec behavior? → Fix directly
+├─ Typo/format/comment? → Fix directly  
+├─ New feature/capability? → Create proposal
+├─ Breaking change? → Create proposal
+├─ Architecture change? → Create proposal
+└─ Unclear? → Create proposal (safer)
+```
+
+### Proposal Structure
+
+1. **Create directory:** `changes/[change-id]/` (kebab-case, verb-led, unique)
+
+2. **Write proposal.md:**
+```markdown
+## Why
+[1-2 sentences on problem/opportunity]
+
+## What Changes
+- [Bullet list of changes]
+- [Mark breaking changes with **BREAKING**]
+
+## Impact
+- Affected specs: [list capabilities]
+- Affected code: [key files/systems]
+```
+
+3. **Create spec deltas:** `specs/[capability]/spec.md`
+```markdown
+## ADDED Requirements
+### Requirement: New Feature
+The system SHALL provide...
+
+#### Scenario: Success case
+- **WHEN** user performs action
+- **THEN** expected result
+
+## MODIFIED Requirements
+### Requirement: Existing Feature
+[Complete modified requirement]
+
+## REMOVED Requirements
+### Requirement: Old Feature
+**Reason**: [Why removing]
+**Migration**: [How to handle]
+```
+If multiple capabilities are affected, create multiple delta files under `changes/[change-id]/specs/<capability>/spec.md`—one per capability.
+
+4. **Create tasks.md:**
+```markdown
+## 1. Implementation
+- [ ] 1.1 Create database schema
+- [ ] 1.2 Implement API endpoint
+- [ ] 1.3 Add frontend component
+- [ ] 1.4 Write tests
+```
+
+5. **Create design.md when needed:**
+Create `design.md` if any of the following apply; otherwise omit it:
+- Cross-cutting change (multiple services/modules) or a new architectural pattern
+- New external dependency or significant data model changes
+- Security, performance, or migration complexity
+- Ambiguity that benefits from technical decisions before coding
+
+Minimal `design.md` skeleton:
+```markdown
+## Context
+[Background, constraints, stakeholders]
+
+## Goals / Non-Goals
+- Goals: [...]
+- Non-Goals: [...]
+
+## Decisions
+- Decision: [What and why]
+- Alternatives considered: [Options + rationale]
+
+## Risks / Trade-offs
+- [Risk] → Mitigation
+
+## Migration Plan
+[Steps, rollback]
+
+## Open Questions
+- [...]
+```
+
+## Spec File Format
+
+### Critical: Scenario Formatting
+
+**CORRECT** (use #### headers):
+```markdown
+#### Scenario: User login success
+- **WHEN** valid credentials provided
+- **THEN** return JWT token
+```
+
+**WRONG** (don't use bullets or bold):
+```markdown
+- **Scenario: User login**  ❌
+**Scenario**: User login     ❌
+### Scenario: User login      ❌
+```
+
+Every requirement MUST have at least one scenario.
+
+### Requirement Wording
+- Use SHALL/MUST for normative requirements (avoid should/may unless intentionally non-normative)
+
+### Delta Operations
+
+- `## ADDED Requirements` - New capabilities
+- `## MODIFIED Requirements` - Changed behavior
+- `## REMOVED Requirements` - Deprecated features
+- `## RENAMED Requirements` - Name changes
+
+Headers matched with `trim(header)` - whitespace ignored.
+
+#### When to use ADDED vs MODIFIED
+- ADDED: Introduces a new capability or sub-capability that can stand alone as a requirement. Prefer ADDED when the change is orthogonal (e.g., adding "Slash Command Configuration") rather than altering the semantics of an existing requirement.
+- MODIFIED: Changes the behavior, scope, or acceptance criteria of an existing requirement. Always paste the full, updated requirement content (header + all scenarios). The archiver will replace the entire requirement with what you provide here; partial deltas will drop previous details.
+- RENAMED: Use when only the name changes. If you also change behavior, use RENAMED (name) plus MODIFIED (content) referencing the new name.
+
+Common pitfall: Using MODIFIED to add a new concern without including the previous text. This causes loss of detail at archive time. If you aren’t explicitly changing the existing requirement, add a new requirement under ADDED instead.
+
+Authoring a MODIFIED requirement correctly:
+1) Locate the existing requirement in `openspec/specs/<capability>/spec.md`.
+2) Copy the entire requirement block (from `### Requirement: ...` through its scenarios).
+3) Paste it under `## MODIFIED Requirements` and edit to reflect the new behavior.
+4) Ensure the header text matches exactly (whitespace-insensitive) and keep at least one `#### Scenario:`.
+
+Example for RENAMED:
+```markdown
+## RENAMED Requirements
+- FROM: `### Requirement: Login`
+- TO: `### Requirement: User Authentication`
+```
+
+## Troubleshooting
+
+### Common Errors
+
+**"Change must have at least one delta"**
+- Check `changes/[name]/specs/` exists with .md files
+- Verify files have operation prefixes (## ADDED Requirements)
+
+**"Requirement must have at least one scenario"**
+- Check scenarios use `#### Scenario:` format (4 hashtags)
+- Don't use bullet points or bold for scenario headers
+
+**Silent scenario parsing failures**
+- Exact format required: `#### Scenario: Name`
+- Debug with: `openspec show [change] --json --deltas-only`
+
+### Validation Tips
+
+```bash
+# Always use strict mode for comprehensive checks
+openspec validate [change] --strict
+
+# Debug delta parsing
+openspec show [change] --json | jq '.deltas'
+
+# Check specific requirement
+openspec show [spec] --json -r 1
+```
+
+## Happy Path Script
+
+```bash
+# 1) Explore current state
+openspec spec list --long
+openspec list
+# Optional full-text search:
+# rg -n "Requirement:|Scenario:" openspec/specs
+# rg -n "^#|Requirement:" openspec/changes
+
+# 2) Choose change id and scaffold
+CHANGE=add-two-factor-auth
+mkdir -p openspec/changes/$CHANGE/{specs/auth}
+printf "## Why\n...\n\n## What Changes\n- ...\n\n## Impact\n- ...\n" > openspec/changes/$CHANGE/proposal.md
+printf "## 1. Implementation\n- [ ] 1.1 ...\n" > openspec/changes/$CHANGE/tasks.md
+
+# 3) Add deltas (example)
+cat > openspec/changes/$CHANGE/specs/auth/spec.md << 'EOF'
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+Users MUST provide a second factor during login.
+
+#### Scenario: OTP required
+- **WHEN** valid credentials are provided
+- **THEN** an OTP challenge is required
+EOF
+
+# 4) Validate
+openspec validate $CHANGE --strict
+```
+
+## Multi-Capability Example
+
+```
+openspec/changes/add-2fa-notify/
+├── proposal.md
+├── tasks.md
+└── specs/
+    ├── auth/
+    │   └── spec.md   # ADDED: Two-Factor Authentication
+    └── notifications/
+        └── spec.md   # ADDED: OTP email notification
+```
+
+auth/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: Two-Factor Authentication
+...
+```
+
+notifications/spec.md
+```markdown
+## ADDED Requirements
+### Requirement: OTP Email Notification
+...
+```
+
+## Best Practices
+
+### Simplicity First
+- Default to <100 lines of new code
+- Single-file implementations until proven insufficient
+- Avoid frameworks without clear justification
+- Choose boring, proven patterns
+
+### Complexity Triggers
+Only add complexity with:
+- Performance data showing current solution too slow
+- Concrete scale requirements (>1000 users, >100MB data)
+- Multiple proven use cases requiring abstraction
+
+### Clear References
+- Use `file.ts:42` format for code locations
+- Reference specs as `specs/auth/spec.md`
+- Link related changes and PRs
+
+### Capability Naming
+- Use verb-noun: `user-auth`, `payment-capture`
+- Single purpose per capability
+- 10-minute understandability rule
+- Split if description needs "AND"
+
+### Change ID Naming
+- Use kebab-case, short and descriptive: `add-two-factor-auth`
+- Prefer verb-led prefixes: `add-`, `update-`, `remove-`, `refactor-`
+- Ensure uniqueness; if taken, append `-2`, `-3`, etc.
+
+## Tool Selection Guide
+
+| Task | Tool | Why |
+|------|------|-----|
+| Find files by pattern | Glob | Fast pattern matching |
+| Search code content | Grep | Optimized regex search |
+| Read specific files | Read | Direct file access |
+| Explore unknown scope | Task | Multi-step investigation |
+
+## Error Recovery
+
+### Change Conflicts
+1. Run `openspec list` to see active changes
+2. Check for overlapping specs
+3. Coordinate with change owners
+4. Consider combining proposals
+
+### Validation Failures
+1. Run with `--strict` flag
+2. Check JSON output for details
+3. Verify spec file format
+4. Ensure scenarios properly formatted
+
+### Missing Context
+1. Read project.md first
+2. Check related specs
+3. Review recent archives
+4. Ask for clarification
+
+## Quick Reference
+
+### Stage Indicators
+- `changes/` - Proposed, not yet built
+- `specs/` - Built and deployed
+- `archive/` - Completed changes
+
+### File Purposes
+- `proposal.md` - Why and what
+- `tasks.md` - Implementation steps
+- `design.md` - Technical decisions
+- `spec.md` - Requirements and behavior
+
+### CLI Essentials
+```bash
+openspec list              # What's in progress?
+openspec show [item]       # View details
+openspec validate --strict # Is it correct?
+openspec archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
+```
+
+Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/openspec/changes/add-custom-steering-dialog/proposal.md
+++ b/openspec/changes/add-custom-steering-dialog/proposal.md
@@ -1,0 +1,14 @@
+## Why
+- The current `create custom steering` command asks for input through the VS Code input box, which limits context sharing, provides no autosave, and diverges from the richer Create New Spec experience.
+- Users want a consistent large-form editor with draft recovery so they can describe steering guidance in depth before sending prompts to Codex.
+
+## What Changes
+- Add a dedicated custom steering dialog webview that mirrors the Create New Spec flow, including focus management, autosave, and close-confirmation behavior.
+- Introduce a steering creation input controller that formats the multi-field form data into the existing `create-custom-steering` prompt payload.
+- Update `SteeringManager.createCustom` and related tests to invoke the new controller while keeping prompt rendering via `PromptLoader` per `.codex/steering/tech.md` integration rules.
+- Extend the webview bundle with a `create-steering` page, React form components, and bridge message types needed for submission, autosave, and cancellation.
+
+## Impact
+- Improves usability and parity between spec creation and steering creation workflows.
+- Keeps steering prompts aligned with manager/provider abstractions defined in `.codex/steering/structure.md` without bypassing shared utilities.
+- Requires new UI strings and tests but no migrations or schema updates.

--- a/openspec/changes/add-custom-steering-dialog/specs/steering-ui/spec.md
+++ b/openspec/changes/add-custom-steering-dialog/specs/steering-ui/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+### Requirement: Custom Steering Creation Dialog
+The extension MUST open a dedicated webview dialog with rich inputs whenever the `kiro-codex-ide.steering.create` command runs, providing parity with the Create New Spec experience and formatting the collected data for the `create-custom-steering` prompt.
+
+#### Scenario: Launch With Draft Recovery
+- **GIVEN** the user previously saved custom steering input via autosave
+- **WHEN** they invoke `kiro-codex-ide.steering.create`
+- **THEN** a `create-steering` webview panel opens in the active editor column with the saved form values loaded
+- **AND** the primary summary textarea receives focus unless the user was editing a different field before the dialog closed.
+
+#### Scenario: Submit Steering Prompt
+- **GIVEN** the user completes all required fields in the custom steering dialog
+- **WHEN** they submit the form
+- **THEN** the dialog sends an aggregated guidance description to the `create-custom-steering` prompt through `PromptLoader`
+- **AND** the extension clears the draft state, shows the existing chat notification, and closes the panel without leaving stray workspace state.

--- a/openspec/changes/add-custom-steering-dialog/tasks.md
+++ b/openspec/changes/add-custom-steering-dialog/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+- [ ] 1.1 Add a `CreateSteeringInputController` (or equivalent) that opens the custom steering dialog webview, manages draft persistence, and formats submission payloads for the `create-custom-steering` prompt.
+- [ ] 1.2 Wire `SteeringManager.createCustom` to the new controller and update extension activation wiring plus unit tests for the new workflow.
+- [ ] 1.3 Build the `create-steering` React view with multi-field form, autosave, and close-confirmation parity with the Create New Spec experience.
+- [ ] 1.4 Add Vitest coverage for the controller and webview bridge logic, ensuring draft persistence, validation, and submission behaviors.
+
+## 2. Validation
+- [ ] 2.1 Manually verify the command in VS Code, including draft recovery, submission success path, and cancel flow with unsaved changes.
+- [ ] 2.2 Run `npm run lint`, `npm run test`, and `npm run check` to confirm steering changes respect project and steering contracts.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,58 @@
+# Project Context
+
+## Purpose
+Kiro for Codex IDE is a Visual Studio Code extension that gives Codex CLI users a guided, spec-driven workflow. It keeps specs, steering rules, and reusable prompts in sync with the Codex chat experience so teams can create, review, and execute change proposals without leaving the IDE.
+
+## Tech Stack
+- TypeScript for the extension runtime, prompt tooling, and shared utilities compiled with `esbuild` for Node 16 targets.
+- VS Code Extension API plus `CodexProvider` helpers for activating commands and integrating with Codex chat.
+- React 18 + Vite + Tailwind CSS 4 for the webview UI that powers the extension’s dialogs and explorers.
+- Handlebars + gray-matter for compiling Markdown prompt templates via `scripts/build-prompts.js`.
+- Vitest test runner with TypeScript configuration and `@vitest/ui` for interactive debugging.
+- Ultracite + Biome for linting, formatting, and static checks across both extension and webview code.
+
+## Project Conventions
+
+### Code Style
+- Follow the steering guidance in `.codex/steering/tech.md` and `.codex/steering/structure.md`; TypeScript source lives under `src/` with generated prompt modules relegated to `src/prompts/target`.
+- Keep filenames in kebab-case, favor `const` declarations, and implement functions as arrow expressions (`const fn = () => {}`) per the project’s TypeScript guidelines.
+- Format with Biome (tab indentation, double quotes, required semicolons) and run `ultracite` commands (`npm run lint`, `npm run format`, `npm run check`) before committing changes.
+- Avoid bypassing shared managers—use `ConfigManager`, `PromptLoader`, `SpecManager`, `SteeringManager`, and `CodexProvider` entry points instead of bespoke file IO or prompt handling.
+
+### Architecture Patterns
+- `src/extension.ts` wires activation, registers VS Code commands, and instantiates tree providers for specs, steering, prompts, and settings.
+- Spec and steering flows live in `src/features/spec` and `src/features/steering`, with managers responsible for reading/writing `.codex` assets and coordinating Codex chat interactions.
+- Providers under `src/providers` expose tree views and CodeLens integrations that call manager methods, keeping UI logic thin and declarative.
+- Prompt ingestion goes through `PromptLoader` (`src/services/prompt-loader.ts`), which compiles Markdown templates into TypeScript modules consumed by the extension.
+- The `webview-ui/` React project (Vite build) renders modal workflows; compiled assets ship in `dist/webview/app` and are loaded via the extension runtime.
+
+### Testing Strategy
+- Use Vitest (`npm test`, `npm run test:watch`, `npm run test:coverage`) for unit and integration coverage of managers, providers, and utilities.
+- Place tests in `tests/` with supporting configuration in `vitest.config.ts` and `vitest.setup.ts`.
+- Mock VS Code APIs and Codex integrations via existing helpers; prefer deterministic fixtures for `.codex` data to keep tests hermetic.
+- Run `ultracite` checks alongside tests to ensure linting and formatting stay aligned with steering expectations.
+
+### Git Workflow
+- Develop changes on feature branches, open pull requests, and merge into `main` once checks pass; releases run from a clean `main` history.
+- Follow Conventional Commits (`feat:`, `fix:`, etc.) so automated changelog generation works inside the release pipeline.
+- Trigger versioned releases via the GitHub Actions workflows documented in `docs/release-process.md` (`version-bump.yml`, `release.yml`, `release-only.yml`)—tags use the `vX.Y.Z` scheme and publish VSIX packages to both VS Code Marketplace and Open VSX.
+- Keep `dist/` outputs build-generated; never commit manual edits to bundled artifacts.
+
+## Domain Context
+- The extension is purpose-built for OpenSpec workflows: it scaffolds proposals, tracks requirements/design/tasks, and keeps steering guides synchronized with Codex chat prompts.
+- Specs, steering documents, and prompts reside under `.codex/`; the activity bar container exposes Specs, Steering, Prompts, and Settings views that mirror this layout.
+- Codex CLI and the VS Code Codex (ChatGPT) extension must be installed so Codex chat can process generated prompts and execute tasks.
+- Managers rely on Codex to refine content—e.g., `SpecManager` sends create/refine requests, while `SteeringManager` preserves AGENTS contracts when documents change.
+
+## Important Constraints
+- Honor product, tech, and structure rules captured in `.codex/steering/*.md`; deviations require updates through the documented steering workflows.
+- Access steering, spec, and prompt paths via `ConfigManager` helpers; do not hardcode `.codex` paths or bypass VS Code `workspace.fs` APIs.
+- Route all Codex interactions through `CodexProvider.invokeCodexSplitView`/`invokeCodexHeadless` to keep chat sessions consistent and temporary payloads under `.codex/tmp`.
+- Avoid silently overwriting user-authored `.codex` content—manager methods guard against unintended deletions and must remain the single touchpoint for file mutations.
+- Maintain separation between extension code and webview bundle; webview assets should be produced via `npm run build:webview` and loaded from `dist/`.
+
+## External Dependencies
+- VS Code 1.84+ runtime and extension API surface area.
+- Codex CLI (≥0.28.0) and the VS Code Codex extension, which provide the chat backend consumed by `CodexProvider`.
+- GitHub Actions workflows leveraging `vsce`, `HaaLeo/publish-vscode-extension`, and publish tokens (`VSCE_PAT`, `OPEN_VSX_TOKEN`) for marketplace releases.
+- Node.js tooling: `esbuild` for bundling, Vite + Tailwind CSS for the webview, and `ultracite`/`biome` binaries for linting and formatting.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,7 @@ export async function activate(context: ExtensionContext) {
 
 	// Initialize feature managers with output channel
 	specManager = new SpecManager(context, outputChannel);
-	steeringManager = new SteeringManager(codexProvider, outputChannel);
+	steeringManager = new SteeringManager(context, codexProvider, outputChannel);
 
 	// Register tree data providers
 	const overviewProvider = new OverviewProvider(context);

--- a/src/features/steering/create-steering-input-controller.test.ts
+++ b/src/features/steering/create-steering-input-controller.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionContext, MessageItem } from "vscode";
+import { Uri, ViewColumn, window, workspace } from "vscode";
+import { CreateSteeringInputController } from "./create-steering-input-controller";
+import type { CreateSteeringDraftState } from "./types";
+import { sendPromptToChat } from "../../utils/chat-prompt-runner";
+import { NotificationUtils } from "../../utils/notification-utils";
+
+vi.mock("../../utils/chat-prompt-runner", () => ({
+	sendPromptToChat: vi.fn(),
+}));
+
+vi.mock("../../utils/notification-utils", () => ({
+	// biome-ignore lint/style/useNamingConvention: ignore
+	NotificationUtils: {
+		showAutoDismissNotification: vi.fn(),
+	},
+}));
+
+describe("CreateSteeringInputController", () => {
+	let context: ExtensionContext;
+	let postMessageMock: ReturnType<typeof vi.fn>;
+	let revealMock: ReturnType<typeof vi.fn>;
+	let disposeMock: ReturnType<typeof vi.fn>;
+	let onDidDisposeMock: ReturnType<typeof vi.fn>;
+	let onDidReceiveMessageMock: ReturnType<typeof vi.fn>;
+	let workspaceStateGetMock: ReturnType<typeof vi.fn>;
+	let workspaceStateUpdateMock: ReturnType<typeof vi.fn>;
+	let configManager: { getPath: ReturnType<typeof vi.fn> };
+	let promptLoader: { renderPrompt: ReturnType<typeof vi.fn> };
+	let outputChannel: { appendLine: ReturnType<typeof vi.fn> };
+	let htmlValue: string;
+	let messageHandler:
+		| ((
+				message:
+					| { type: "create-steering/submit"; payload: any }
+					| { type: "create-steering/autosave"; payload: any }
+					| {
+							type: "create-steering/close-attempt";
+							payload: { hasDirtyChanges: boolean };
+					  }
+					| { type: "create-steering/cancel" }
+					| { type: "create-steering/ready" }
+		  ) => Promise<void>)
+		| undefined;
+
+	const createMessageItem = (title: string): MessageItem => ({ title });
+
+	const createController = () =>
+		new CreateSteeringInputController({
+			context,
+			configManager: configManager as any,
+			promptLoader: promptLoader as any,
+			outputChannel: outputChannel as any,
+		});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		htmlValue = "";
+		messageHandler = undefined;
+
+		workspaceStateGetMock = vi.fn();
+		workspaceStateUpdateMock = vi.fn();
+
+		context = {
+			extensionUri: Uri.parse("file:///extension"),
+			workspaceState: {
+				get: workspaceStateGetMock,
+				update: workspaceStateUpdateMock,
+			},
+			subscriptions: [],
+		} as unknown as ExtensionContext;
+
+		configManager = {
+			getPath: vi.fn().mockReturnValue(".codex/steering"),
+		};
+
+		promptLoader = {
+			renderPrompt: vi.fn().mockReturnValue("steering-prompt"),
+		};
+
+		outputChannel = {
+			appendLine: vi.fn(),
+		};
+
+		postMessageMock = vi.fn().mockResolvedValue(true);
+		revealMock = vi.fn();
+		disposeMock = vi.fn();
+		onDidDisposeMock = vi.fn((callback: () => void) => ({
+			dispose: vi.fn(() => {
+				callback();
+			}),
+		}));
+
+		onDidReceiveMessageMock = vi.fn(
+			(
+				handler: (
+					message:
+						| { type: "create-steering/submit"; payload: any }
+						| { type: "create-steering/autosave"; payload: any }
+						| {
+								type: "create-steering/close-attempt";
+								payload: { hasDirtyChanges: boolean };
+						  }
+						| { type: "create-steering/cancel" }
+						| { type: "create-steering/ready" }
+				) => Promise<void>
+			) => {
+				messageHandler = handler;
+				return { dispose: vi.fn() };
+			}
+		);
+
+		const webview = {
+			asWebviewUri: vi.fn((resource) => resource),
+			cspSource: "mock-csp",
+			postMessage: postMessageMock,
+			onDidReceiveMessage: onDidReceiveMessageMock,
+		} as any;
+
+		Object.defineProperty(webview, "html", {
+			get: () => htmlValue,
+			set: (value: string) => {
+				htmlValue = value;
+			},
+		});
+
+		const panel = {
+			webview,
+			reveal: revealMock,
+			dispose: disposeMock,
+			onDidDispose: onDidDisposeMock,
+		} as any;
+
+		(window as any).createWebviewPanel = vi.fn(() => panel);
+		vi.mocked(sendPromptToChat).mockResolvedValue(undefined);
+		(window as any).showWarningMessage = window.showWarningMessage;
+		vi.mocked(window.showWarningMessage).mockResolvedValue(
+			createMessageItem("Cancel")
+		);
+		vi.mocked(workspace.fs.createDirectory).mockResolvedValue(undefined);
+	});
+
+	const emitMessage = async (message: any) => {
+		if (!messageHandler) {
+			throw new Error("message handler not registered");
+		}
+		await messageHandler(message);
+	};
+
+	it("opens panel and posts init message with focus flag", async () => {
+		const controller = createController();
+		await controller.open();
+
+		expect((window as any).createWebviewPanel).toHaveBeenCalledWith(
+			"kiro.createSteeringDialog",
+			"Create Custom Steering",
+			{
+				viewColumn: ViewColumn.Active,
+				preserveFocus: false,
+			},
+			expect.objectContaining({
+				enableScripts: true,
+				retainContextWhenHidden: true,
+			})
+		);
+		expect(postMessageMock).toHaveBeenCalledWith({
+			type: "create-steering/init",
+			payload: {
+				draft: undefined,
+				shouldFocusPrimaryField: true,
+			},
+		});
+		expect(htmlValue).toContain('data-page="create-steering"');
+	});
+
+	it("restores saved draft state when available", async () => {
+		const draft: CreateSteeringDraftState = {
+			formData: {
+				summary: "Saved summary",
+				audience: "frontend team",
+				keyPractices: "Follow hooks rules",
+				antiPatterns: "Avoid console logs",
+			},
+			lastUpdated: 999,
+		};
+
+		workspaceStateGetMock.mockReturnValueOnce(draft);
+
+		const controller = createController();
+		await controller.open();
+
+		expect(postMessageMock).toHaveBeenCalledWith({
+			type: "create-steering/init",
+			payload: {
+				draft,
+				shouldFocusPrimaryField: true,
+			},
+		});
+	});
+
+	it("submits steering prompt with normalized payload", async () => {
+		const controller = createController();
+		await controller.open();
+
+		await emitMessage({
+			type: "create-steering/submit",
+			payload: {
+				summary: "  Improve API docs ",
+				audience: "API team",
+				keyPractices: "Document request/response examples",
+				antiPatterns: "Skipping error cases",
+			},
+		});
+
+		expect(workspace.fs.createDirectory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				fsPath: "/fake/workspace/.codex/steering",
+			})
+		);
+		expect(promptLoader.renderPrompt).toHaveBeenCalledWith(
+			"create-custom-steering",
+			expect.objectContaining({
+				description: expect.stringContaining(
+					"Guidance Summary:\nImprove API docs"
+				),
+				steeringPath: ".codex/steering",
+			})
+		);
+		expect(sendPromptToChat).toHaveBeenCalledWith("steering-prompt");
+		expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalled();
+		expect(workspaceStateUpdateMock).toHaveBeenCalledWith(
+			"createSteeringDraftState",
+			undefined
+		);
+		expect(disposeMock).toHaveBeenCalled();
+	});
+
+	it("returns validation error when summary missing", async () => {
+		const controller = createController();
+		await controller.open();
+
+		await emitMessage({
+			type: "create-steering/submit",
+			payload: {
+				summary: "   ",
+				audience: "",
+				keyPractices: "",
+				antiPatterns: "",
+			},
+		});
+
+		expect(postMessageMock).toHaveBeenLastCalledWith({
+			payload: { message: "Guidance summary is required." },
+			type: "create-steering/submit:error",
+		});
+		expect(sendPromptToChat).not.toHaveBeenCalled();
+	});
+
+	it("persists autosave drafts and handles close cancellation", async () => {
+		const controller = createController();
+		await controller.open();
+
+		await emitMessage({
+			type: "create-steering/autosave",
+			payload: {
+				summary: "Partial summary",
+				audience: "",
+				keyPractices: "",
+				antiPatterns: "",
+			},
+		});
+
+		expect(workspaceStateUpdateMock).toHaveBeenCalledWith(
+			"createSteeringDraftState",
+			expect.objectContaining({
+				formData: expect.objectContaining({ summary: "Partial summary" }),
+			})
+		);
+
+		await emitMessage({
+			type: "create-steering/close-attempt",
+			payload: { hasDirtyChanges: true },
+		});
+
+		expect(postMessageMock).toHaveBeenLastCalledWith({
+			type: "create-steering/confirm-close",
+			payload: { shouldClose: false },
+		});
+	});
+});

--- a/src/features/steering/create-steering-input-controller.ts
+++ b/src/features/steering/create-steering-input-controller.ts
@@ -1,0 +1,345 @@
+import { join } from "path";
+import {
+	type ExtensionContext,
+	type MessageItem,
+	type OutputChannel,
+	Uri,
+	ViewColumn,
+	type WebviewPanel,
+	window,
+	workspace,
+} from "vscode";
+import type { PromptLoader } from "../../services/prompt-loader";
+import type { ConfigManager } from "../../utils/config-manager";
+import { sendPromptToChat } from "../../utils/chat-prompt-runner";
+import { getWebviewContent } from "../../utils/get-webview-content";
+import { NotificationUtils } from "../../utils/notification-utils";
+import type {
+	CreateSteeringDraftState,
+	CreateSteeringExtensionMessage,
+	CreateSteeringFormData,
+	CreateSteeringWebviewMessage,
+} from "./types";
+
+type CreateSteeringInputControllerDependencies = {
+	context: ExtensionContext;
+	configManager: ConfigManager;
+	promptLoader: PromptLoader;
+	outputChannel: OutputChannel;
+};
+
+const CREATE_STEERING_DRAFT_STATE_KEY = "createSteeringDraftState";
+
+const isMessageItem = (value: unknown): value is MessageItem => {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+
+	const candidate = value as { title?: unknown };
+	return typeof candidate.title === "string";
+};
+
+const normalizeFormData = (
+	data: CreateSteeringFormData
+): CreateSteeringFormData => ({
+	summary: data.summary ?? "",
+	audience: data.audience ?? "",
+	keyPractices: data.keyPractices ?? "",
+	antiPatterns: data.antiPatterns ?? "",
+});
+
+const formatDescription = (data: CreateSteeringFormData): string => {
+	const sections = [
+		`Guidance Summary:\n${data.summary.trim()}`,
+		data.audience.trim()
+			? `Audience & Ownership:\n${data.audience.trim()}`
+			: undefined,
+		data.keyPractices.trim()
+			? `Key Practices to Follow:\n${data.keyPractices.trim()}`
+			: undefined,
+		data.antiPatterns.trim()
+			? `Pitfalls to Avoid:\n${data.antiPatterns.trim()}`
+			: undefined,
+	].filter(Boolean);
+
+	return sections.join("\n\n");
+};
+
+export class CreateSteeringInputController {
+	private readonly context: ExtensionContext;
+	private readonly configManager: ConfigManager;
+	private readonly promptLoader: PromptLoader;
+	private readonly outputChannel: OutputChannel;
+	private draft: CreateSteeringDraftState | undefined;
+	private panel: WebviewPanel | undefined;
+
+	constructor({
+		context,
+		configManager,
+		promptLoader,
+		outputChannel,
+	}: CreateSteeringInputControllerDependencies) {
+		this.context = context;
+		this.configManager = configManager;
+		this.promptLoader = promptLoader;
+		this.outputChannel = outputChannel;
+	}
+
+	async open(): Promise<void> {
+		if (this.panel) {
+			this.panel.reveal(ViewColumn.Active, false);
+			await this.postFocusMessage();
+			return;
+		}
+
+		const workspaceFolder = workspace.workspaceFolders?.[0];
+		if (!workspaceFolder) {
+			window.showErrorMessage("No workspace folder open");
+			return;
+		}
+
+		this.draft = this.getDraftState();
+
+		this.panel = this.createPanel();
+		if (!this.panel) {
+			window.showErrorMessage("Unable to open Create Steering dialog");
+			return;
+		}
+
+		this.registerPanelListeners(this.panel);
+		this.panel.webview.html = getWebviewContent(
+			this.panel.webview,
+			this.context.extensionUri,
+			"create-steering"
+		);
+		await this.postInitMessage();
+	}
+
+	private createPanel(): WebviewPanel | undefined {
+		const resourceRoots = [
+			Uri.joinPath(this.context.extensionUri, "dist", "webview"),
+			Uri.joinPath(this.context.extensionUri, "dist", "webview", "app"),
+		];
+
+		try {
+			return window.createWebviewPanel(
+				"kiro.createSteeringDialog",
+				"Create Custom Steering",
+				{
+					viewColumn: ViewColumn.Active,
+					preserveFocus: false,
+				},
+				{
+					enableScripts: true,
+					retainContextWhenHidden: true,
+					localResourceRoots: resourceRoots,
+				}
+			);
+		} catch (error) {
+			this.outputChannel.appendLine(
+				`[CreateSteeringInputController] Failed to open modal panel: ${error}`
+			);
+			try {
+				return window.createWebviewPanel(
+					"kiro.createSteeringPanel",
+					"Create Custom Steering",
+					ViewColumn.Active,
+					{
+						enableScripts: true,
+						retainContextWhenHidden: true,
+						localResourceRoots: resourceRoots,
+					}
+				);
+			} catch (fallbackError) {
+				this.outputChannel.appendLine(
+					`[CreateSteeringInputController] Fallback panel creation failed: ${fallbackError}`
+				);
+				return;
+			}
+		}
+	}
+
+	private registerPanelListeners(panel: WebviewPanel): void {
+		panel.onDidDispose(() => {
+			this.panel = undefined;
+		});
+
+		panel.webview.onDidReceiveMessage(
+			async (message: CreateSteeringWebviewMessage) => {
+				if (message.type === "create-steering/submit") {
+					await this.handleSubmit(message.payload);
+					return;
+				}
+
+				if (message.type === "create-steering/autosave") {
+					await this.handleAutosave(message.payload);
+					return;
+				}
+
+				if (message.type === "create-steering/close-attempt") {
+					await this.handleCloseAttempt(message.payload.hasDirtyChanges);
+					return;
+				}
+
+				if (message.type === "create-steering/cancel") {
+					panel.dispose();
+				}
+			}
+		);
+	}
+
+	private async postInitMessage(): Promise<void> {
+		if (!this.panel) {
+			return;
+		}
+
+		const message: CreateSteeringExtensionMessage = {
+			type: "create-steering/init",
+			payload: {
+				draft: this.draft,
+				shouldFocusPrimaryField: true,
+			},
+		};
+
+		await this.panel.webview.postMessage(message);
+	}
+
+	private async postFocusMessage(): Promise<void> {
+		if (!this.panel) {
+			return;
+		}
+
+		const message: CreateSteeringExtensionMessage = {
+			type: "create-steering/focus",
+		};
+
+		await this.panel.webview.postMessage(message);
+	}
+
+	private async handleSubmit(data: CreateSteeringFormData): Promise<void> {
+		if (!this.panel) {
+			return;
+		}
+
+		const workspaceFolder = workspace.workspaceFolders?.[0];
+		if (!workspaceFolder) {
+			window.showErrorMessage("No workspace folder open");
+			return;
+		}
+
+		const sanitizedSummary = data.summary?.trim();
+		if (!sanitizedSummary) {
+			await this.panel.webview.postMessage({
+				type: "create-steering/submit:error",
+				payload: { message: "Guidance summary is required." },
+			});
+			return;
+		}
+
+		const normalized = normalizeFormData({
+			...data,
+			summary: sanitizedSummary,
+		});
+
+		const payload = formatDescription(normalized);
+
+		const steeringRelativePath = this.configManager.getPath("steering");
+		const steeringPath = join(workspaceFolder.uri.fsPath, steeringRelativePath);
+
+		try {
+			await workspace.fs.createDirectory(Uri.file(steeringPath));
+
+			const prompt = this.promptLoader.renderPrompt("create-custom-steering", {
+				description: payload,
+				steeringPath: steeringRelativePath,
+			});
+
+			await sendPromptToChat(prompt);
+			NotificationUtils.showAutoDismissNotification(
+				"Sent the steering creation prompt to ChatGPT. Continue the conversation there."
+			);
+
+			await this.clearDraftState();
+
+			await this.panel.webview.postMessage({
+				type: "create-steering/submit:success",
+			});
+			this.panel.dispose();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.outputChannel.appendLine(
+				`[CreateSteeringInputController] Failed to submit steering request: ${message}`
+			);
+
+			await this.panel.webview.postMessage({
+				type: "create-steering/submit:error",
+				payload: { message },
+			});
+			window.showErrorMessage(`Failed to create steering prompt: ${message}`);
+		}
+	}
+
+	private async handleAutosave(data: CreateSteeringFormData): Promise<void> {
+		this.draft = {
+			formData: normalizeFormData(data),
+			lastUpdated: Date.now(),
+		};
+		await this.saveDraftState(this.draft);
+	}
+
+	private async handleCloseAttempt(hasDirtyChanges: boolean): Promise<void> {
+		if (!this.panel) {
+			return;
+		}
+
+		if (!hasDirtyChanges) {
+			await this.clearDraftState();
+			this.panel.dispose();
+			return;
+		}
+
+		const result = await window.showWarningMessage(
+			"You have unsaved steering input. Close the dialog and discard your changes?",
+			{
+				modal: true,
+				detail: "Choose Cancel to resume editing and keep your current input.",
+			},
+			"Discard"
+		);
+
+		const selection = isMessageItem(result) ? result.title : result;
+		const shouldClose = selection === "Discard";
+
+		if (shouldClose) {
+			await this.clearDraftState();
+			this.panel.dispose();
+			return;
+		}
+
+		await this.panel.webview.postMessage({
+			type: "create-steering/confirm-close",
+			payload: { shouldClose: false },
+		});
+	}
+
+	private getDraftState(): CreateSteeringDraftState | undefined {
+		return this.context.workspaceState.get<CreateSteeringDraftState>(
+			CREATE_STEERING_DRAFT_STATE_KEY
+		);
+	}
+
+	private async saveDraftState(state: CreateSteeringDraftState): Promise<void> {
+		await this.context.workspaceState.update(
+			CREATE_STEERING_DRAFT_STATE_KEY,
+			state
+		);
+	}
+
+	private async clearDraftState(): Promise<void> {
+		this.draft = undefined;
+		await this.context.workspaceState.update(
+			CREATE_STEERING_DRAFT_STATE_KEY,
+			undefined
+		);
+	}
+}

--- a/src/features/steering/types.ts
+++ b/src/features/steering/types.ts
@@ -1,0 +1,57 @@
+export type CreateSteeringFormData = {
+	summary: string;
+	audience: string;
+	keyPractices: string;
+	antiPatterns: string;
+};
+
+export type CreateSteeringDraftState = {
+	formData: CreateSteeringFormData;
+	lastUpdated: number;
+};
+
+export type CreateSteeringInitPayload = {
+	shouldFocusPrimaryField: boolean;
+	draft?: CreateSteeringDraftState;
+};
+
+export type CreateSteeringExtensionMessage =
+	| { type: "create-steering/init"; payload: CreateSteeringInitPayload }
+	| { type: "create-steering/submit:success" }
+	| { type: "create-steering/submit:error"; payload: { message: string } }
+	| { type: "create-steering/confirm-close"; payload: { shouldClose: boolean } }
+	| { type: "create-steering/focus" };
+
+export type CreateSteeringFieldErrors = {
+	summary?: string;
+};
+
+export type CreateSteeringSubmitMessage = {
+	type: "create-steering/submit";
+	payload: CreateSteeringFormData;
+};
+
+export type CreateSteeringAutosaveMessage = {
+	type: "create-steering/autosave";
+	payload: CreateSteeringFormData;
+};
+
+export type CreateSteeringCloseAttemptMessage = {
+	type: "create-steering/close-attempt";
+	payload: { hasDirtyChanges: boolean };
+};
+
+export type CreateSteeringCancelMessage = {
+	type: "create-steering/cancel";
+};
+
+export type CreateSteeringReadyMessage = {
+	type: "create-steering/ready";
+};
+
+export type CreateSteeringWebviewMessage =
+	| CreateSteeringSubmitMessage
+	| CreateSteeringAutosaveMessage
+	| CreateSteeringCloseAttemptMessage
+	| CreateSteeringCancelMessage
+	| CreateSteeringReadyMessage;

--- a/webview-ui/src/features/create-steering-view/components/create-steering-form.tsx
+++ b/webview-ui/src/features/create-steering-view/components/create-steering-form.tsx
@@ -1,0 +1,173 @@
+import { TextareaPanel } from "@/components/textarea-panel";
+import { Button } from "@/components/ui/button";
+import type { ChangeEvent, FormEvent, MutableRefObject } from "react";
+import type {
+	CreateSteeringFieldErrors,
+	CreateSteeringFormData,
+} from "../types";
+
+const SUMMARY_HELPER_ID = "create-steering-summary-helper";
+
+type CreateSteeringFormProps = {
+	formData: CreateSteeringFormData;
+	fieldErrors: CreateSteeringFieldErrors;
+	isSubmitting: boolean;
+	autosaveStatus: string;
+	onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+	onCancel: () => void;
+	onFieldChange: (
+		field: keyof CreateSteeringFormData
+	) => (event: ChangeEvent<HTMLTextAreaElement>) => void;
+	summaryRef: MutableRefObject<HTMLTextAreaElement | null>;
+	audienceRef: MutableRefObject<HTMLTextAreaElement | null>;
+	keyPracticesRef: MutableRefObject<HTMLTextAreaElement | null>;
+	antiPatternsRef: MutableRefObject<HTMLTextAreaElement | null>;
+};
+
+export const CreateSteeringForm = ({
+	formData,
+	fieldErrors,
+	isSubmitting,
+	autosaveStatus,
+	onSubmit,
+	onCancel,
+	onFieldChange,
+	summaryRef,
+	audienceRef,
+	keyPracticesRef,
+	antiPatternsRef,
+}: CreateSteeringFormProps) => (
+	<form
+		aria-busy={isSubmitting}
+		className="flex flex-1 flex-col gap-6"
+		noValidate
+		onSubmit={onSubmit}
+	>
+		<section className="flex flex-1 flex-col gap-4">
+			<div className="flex flex-col gap-2">
+				<label
+					className="font-medium text-[color:var(--vscode-foreground)] text-sm"
+					htmlFor="create-steering-summary"
+				>
+					Guidance Summary{" "}
+					<span className="text-[color:var(--vscode-errorForeground)]">*</span>
+				</label>
+				<TextareaPanel
+					containerClassName="shadow-[0_16px_32px_rgba(0,0,0,0.25)]"
+					disabled={isSubmitting}
+					onChange={onFieldChange("summary")}
+					placeholder="Describe the core guidance you want agents to follow…"
+					rows={4}
+					textareaClassName="min-h-[6rem] max-h-[60vh] overflow-y-auto text-sm leading-6"
+					textareaProps={{
+						id: "create-steering-summary",
+						name: "summary",
+						"aria-required": true,
+						"aria-invalid": fieldErrors.summary ? true : undefined,
+						"aria-describedby": fieldErrors.summary
+							? SUMMARY_HELPER_ID
+							: undefined,
+					}}
+					textareaRef={summaryRef}
+					value={formData.summary}
+				>
+					{fieldErrors.summary ? (
+						<div
+							className="flex items-center justify-end px-3 py-2 text-[color:var(--vscode-descriptionForeground,rgba(255,255,255,0.6))] text-xs"
+							id={SUMMARY_HELPER_ID}
+						>
+							<span className="text-[color:var(--vscode-errorForeground)]">
+								{fieldErrors.summary}
+							</span>
+						</div>
+					) : null}
+				</TextareaPanel>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					className="font-medium text-[color:var(--vscode-foreground)] text-sm"
+					htmlFor="create-steering-audience"
+				>
+					Audience & Ownership
+				</label>
+				<TextareaPanel
+					disabled={isSubmitting}
+					onChange={onFieldChange("audience")}
+					placeholder="Who should follow this guidance? Include roles, teams, or repos…"
+					rows={3}
+					textareaClassName="min-h-[5rem] max-h-[60vh] overflow-y-auto text-sm leading-6"
+					textareaProps={{
+						id: "create-steering-audience",
+						name: "audience",
+					}}
+					textareaRef={audienceRef}
+					value={formData.audience}
+				/>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					className="font-medium text-[color:var(--vscode-foreground)] text-sm"
+					htmlFor="create-steering-key-practices"
+				>
+					Key Practices to Follow
+				</label>
+				<TextareaPanel
+					disabled={isSubmitting}
+					onChange={onFieldChange("keyPractices")}
+					placeholder="List the behaviors, patterns, or examples the agent must follow…"
+					rows={3}
+					textareaClassName="min-h-[5rem] max-h-[60vh] overflow-y-auto text-sm leading-6"
+					textareaProps={{
+						id: "create-steering-key-practices",
+						name: "keyPractices",
+					}}
+					textareaRef={keyPracticesRef}
+					value={formData.keyPractices}
+				/>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<label
+					className="font-medium text-[color:var(--vscode-foreground)] text-sm"
+					htmlFor="create-steering-anti-patterns"
+				>
+					Pitfalls to Avoid
+				</label>
+				<TextareaPanel
+					disabled={isSubmitting}
+					onChange={onFieldChange("antiPatterns")}
+					placeholder="Capture anti-patterns, gotchas, or things agents must never do…"
+					rows={3}
+					textareaClassName="min-h-[5rem] max-h-[60vh] overflow-y-auto text-sm leading-6"
+					textareaProps={{
+						id: "create-steering-anti-patterns",
+						name: "antiPatterns",
+					}}
+					textareaRef={antiPatternsRef}
+					value={formData.antiPatterns}
+				/>
+			</div>
+		</section>
+
+		<footer className="flex flex-col gap-3 border-[color:color-mix(in_srgb,var(--vscode-foreground)_12%,transparent)] border-t pt-4">
+			<div className="flex flex-wrap items-center justify-between gap-3 text-[color:var(--vscode-descriptionForeground,rgba(255,255,255,0.6))] text-xs">
+				<span>{autosaveStatus}</span>
+			</div>
+			<div className="flex flex-wrap justify-end gap-3">
+				<Button
+					disabled={isSubmitting}
+					onClick={onCancel}
+					type="button"
+					variant="secondary"
+				>
+					Cancel
+				</Button>
+				<Button disabled={isSubmitting} type="submit" variant="default">
+					{isSubmitting ? "Creating…" : "Create Steering"}
+				</Button>
+			</div>
+		</footer>
+	</form>
+);

--- a/webview-ui/src/features/create-steering-view/index.tsx
+++ b/webview-ui/src/features/create-steering-view/index.tsx
@@ -1,0 +1,380 @@
+import { vscode } from "@/bridge/vscode";
+import { CreateSteeringForm } from "./components/create-steering-form";
+import { StatusBanner } from "../create-spec-view/components/status-banner";
+import type {
+	CreateSteeringDraftState,
+	CreateSteeringExtensionMessage,
+	CreateSteeringFieldErrors,
+	CreateSteeringFormData,
+	CreateSteeringInitPayload,
+} from "./types";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ChangeEvent,
+	type FormEvent,
+} from "react";
+
+const EMPTY_FORM: CreateSteeringFormData = {
+	summary: "",
+	audience: "",
+	keyPractices: "",
+	antiPatterns: "",
+};
+
+const AUTOSAVE_DEBOUNCE_MS = 600;
+const normalizeFormData = (
+	data: Partial<CreateSteeringFormData> | undefined
+): CreateSteeringFormData => ({
+	summary: typeof data?.summary === "string" ? data.summary : "",
+	audience: typeof data?.audience === "string" ? data.audience : "",
+	keyPractices: typeof data?.keyPractices === "string" ? data.keyPractices : "",
+	antiPatterns: typeof data?.antiPatterns === "string" ? data.antiPatterns : "",
+});
+
+const areFormsEqual = (
+	left: CreateSteeringFormData,
+	right: CreateSteeringFormData
+): boolean =>
+	left.summary === right.summary &&
+	left.audience === right.audience &&
+	left.keyPractices === right.keyPractices &&
+	left.antiPatterns === right.antiPatterns;
+
+const formatTimestamp = (timestamp: number | undefined): string | undefined => {
+	if (!timestamp) {
+		return;
+	}
+
+	try {
+		return new Intl.DateTimeFormat(undefined, {
+			hour: "2-digit",
+			minute: "2-digit",
+		}).format(new Date(timestamp));
+	} catch {
+		return;
+	}
+};
+
+const readPersistedDraft = (): CreateSteeringDraftState | undefined => {
+	const raw = vscode.getState() as CreateSteeringDraftState | undefined;
+	if (!raw) {
+		return;
+	}
+
+	if (!raw.formData || typeof raw.lastUpdated !== "number") {
+		return;
+	}
+
+	return {
+		formData: normalizeFormData(raw.formData),
+		lastUpdated: raw.lastUpdated,
+	};
+};
+
+export const CreateSteeringView = () => {
+	const [formData, setFormData] = useState<CreateSteeringFormData>(EMPTY_FORM);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [fieldErrors, setFieldErrors] = useState<CreateSteeringFieldErrors>({});
+	const [submissionError, setSubmissionError] = useState<string | undefined>();
+	const [draftSavedAt, setDraftSavedAt] = useState<number | undefined>();
+	const [closeWarningVisible, setCloseWarningVisible] = useState(false);
+
+	const lastPersistedRef = useRef<CreateSteeringFormData>(EMPTY_FORM);
+	const autosaveTimeoutRef = useRef<number | undefined>();
+
+	const summaryRef = useRef<HTMLTextAreaElement>(null);
+	const audienceRef = useRef<HTMLTextAreaElement>(null);
+	const keyPracticesRef = useRef<HTMLTextAreaElement>(null);
+	const antiPatternsRef = useRef<HTMLTextAreaElement>(null);
+
+	const isDirty = useMemo(
+		() => !areFormsEqual(formData, lastPersistedRef.current),
+		[formData]
+	);
+
+	const clearAutosaveTimer = useCallback(() => {
+		if (autosaveTimeoutRef.current) {
+			window.clearTimeout(autosaveTimeoutRef.current);
+			autosaveTimeoutRef.current = undefined;
+		}
+	}, []);
+
+	const persistDraft = useCallback((data: CreateSteeringFormData) => {
+		const normalized = normalizeFormData(data);
+		if (areFormsEqual(normalized, lastPersistedRef.current)) {
+			return;
+		}
+
+		const nextState: CreateSteeringDraftState = {
+			formData: normalized,
+			lastUpdated: Date.now(),
+		};
+
+		lastPersistedRef.current = normalized;
+		setDraftSavedAt(nextState.lastUpdated);
+		vscode.setState(nextState);
+		vscode.postMessage({
+			type: "create-steering/autosave",
+			payload: normalized,
+		});
+	}, []);
+
+	const scheduleAutosave = useCallback(
+		(data: CreateSteeringFormData) => {
+			clearAutosaveTimer();
+			autosaveTimeoutRef.current = window.setTimeout(() => {
+				persistDraft(data);
+			}, AUTOSAVE_DEBOUNCE_MS);
+		},
+		[clearAutosaveTimer, persistDraft]
+	);
+
+	const handleFieldChange = useCallback(
+		(field: keyof CreateSteeringFormData) =>
+			(event: ChangeEvent<HTMLTextAreaElement>) => {
+				const value = event.target.value;
+				setFormData((previous) => {
+					const next = {
+						...previous,
+						[field]: value,
+					};
+					scheduleAutosave(next);
+					return next;
+				});
+			},
+		[scheduleAutosave]
+	);
+
+	const validateForm = useCallback(
+		(current: CreateSteeringFormData): boolean => {
+			const trimmedSummary = current.summary.trim();
+			if (!trimmedSummary) {
+				setFieldErrors({ summary: "Guidance summary is required." });
+				summaryRef.current?.focus();
+				return false;
+			}
+
+			setFieldErrors({});
+			return true;
+		},
+		[]
+	);
+
+	const handleSubmit = useCallback(
+		(event: FormEvent<HTMLFormElement>) => {
+			event.preventDefault();
+			if (isSubmitting) {
+				return;
+			}
+
+			const normalized = normalizeFormData({
+				...formData,
+				summary: formData.summary.trim(),
+			});
+
+			if (!validateForm(normalized)) {
+				return;
+			}
+
+			clearAutosaveTimer();
+			setIsSubmitting(true);
+			setSubmissionError(undefined);
+
+			vscode.postMessage({
+				type: "create-steering/submit",
+				payload: normalized,
+			});
+		},
+		[clearAutosaveTimer, formData, isSubmitting, validateForm]
+	);
+
+	const handleCancel = useCallback(() => {
+		clearAutosaveTimer();
+		vscode.postMessage({
+			type: "create-steering/close-attempt",
+			payload: { hasDirtyChanges: isDirty },
+		});
+	}, [clearAutosaveTimer, isDirty]);
+
+	const focusSummaryField = useCallback(() => {
+		window.setTimeout(() => {
+			summaryRef.current?.focus();
+		}, 0);
+	}, []);
+
+	const handleInitMessage = useCallback(
+		(initPayload?: CreateSteeringInitPayload) => {
+			const draftData = normalizeFormData(initPayload?.draft?.formData);
+			lastPersistedRef.current = draftData;
+			setFormData(draftData);
+			setDraftSavedAt(initPayload?.draft?.lastUpdated);
+			setSubmissionError(undefined);
+			setIsSubmitting(false);
+			setFieldErrors({});
+			setCloseWarningVisible(false);
+			vscode.setState(initPayload?.draft);
+
+			if (initPayload?.shouldFocusPrimaryField) {
+				focusSummaryField();
+			}
+		},
+		[focusSummaryField]
+	);
+
+	useEffect(() => {
+		const persistedDraft = readPersistedDraft();
+		if (persistedDraft) {
+			lastPersistedRef.current = persistedDraft.formData;
+			setFormData(persistedDraft.formData);
+			setDraftSavedAt(persistedDraft.lastUpdated);
+		}
+
+		vscode.postMessage({ type: "create-steering/ready" });
+
+		return () => {
+			clearAutosaveTimer();
+		};
+	}, [clearAutosaveTimer]);
+
+	useEffect(() => {
+		const handleMessage = (
+			event: MessageEvent<CreateSteeringExtensionMessage>
+		) => {
+			const payload = event.data;
+			if (!payload || typeof payload !== "object") {
+				return;
+			}
+
+			switch (payload.type) {
+				case "create-steering/init": {
+					handleInitMessage(payload.payload);
+					break;
+				}
+				case "create-steering/submit:success": {
+					setIsSubmitting(false);
+					setSubmissionError(undefined);
+					break;
+				}
+				case "create-steering/submit:error": {
+					setIsSubmitting(false);
+					setSubmissionError(
+						payload.payload?.message ?? "Failed to submit steering prompt."
+					);
+					break;
+				}
+				case "create-steering/confirm-close": {
+					setCloseWarningVisible(!payload.payload?.shouldClose);
+					break;
+				}
+				case "create-steering/focus": {
+					focusSummaryField();
+					break;
+				}
+				default:
+					break;
+			}
+		};
+
+		window.addEventListener("message", handleMessage);
+		return () => {
+			window.removeEventListener("message", handleMessage);
+		};
+	}, [focusSummaryField, handleInitMessage]);
+
+	useEffect(() => {
+		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+			if (!isDirty) {
+				return;
+			}
+
+			event.preventDefault();
+			event.returnValue = "";
+			vscode.postMessage({
+				type: "create-steering/close-attempt",
+				payload: { hasDirtyChanges: true },
+			});
+		};
+
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+		};
+	}, [isDirty]);
+
+	const statusBanner = useMemo(() => {
+		if (submissionError) {
+			return (
+				<StatusBanner ariaLive="assertive" role="alert" tone="error">
+					{submissionError}
+				</StatusBanner>
+			);
+		}
+
+		if (closeWarningVisible) {
+			return (
+				<StatusBanner role="status" tone="warning">
+					Changes are still available. Close action was cancelled.
+				</StatusBanner>
+			);
+		}
+
+		if (isSubmitting) {
+			return (
+				<StatusBanner role="status" tone="info">
+					Sending steering prompt…
+				</StatusBanner>
+			);
+		}
+
+		return null;
+	}, [closeWarningVisible, isSubmitting, submissionError]);
+
+	const lastSavedLabel = formatTimestamp(draftSavedAt);
+	const autosaveStatus = useMemo(() => {
+		if (lastSavedLabel) {
+			return `Draft saved at ${lastSavedLabel}`;
+		}
+
+		if (isDirty) {
+			return "Unsaved changes";
+		}
+
+		return "All changes saved";
+	}, [isDirty, lastSavedLabel]);
+
+	return (
+		<div className="mx-auto flex h-full w-full max-w-4xl flex-col gap-6 px-4 py-6">
+			<header className="flex flex-col gap-2">
+				<h1 className="font-semibold text-2xl text-[color:var(--vscode-foreground)]">
+					Create Custom Steering
+				</h1>
+				<p className="text-[color:var(--vscode-descriptionForeground,rgba(255,255,255,0.65))] text-sm">
+					Share the guardrails and project-specific rules you want every agent
+					to follow. Summary is required; other sections are optional.
+				</p>
+			</header>
+
+			{statusBanner}
+
+			<CreateSteeringForm
+				antiPatternsRef={antiPatternsRef}
+				audienceRef={audienceRef}
+				autosaveStatus={autosaveStatus}
+				fieldErrors={fieldErrors}
+				formData={formData}
+				isSubmitting={isSubmitting}
+				keyPracticesRef={keyPracticesRef}
+				onCancel={handleCancel}
+				onFieldChange={handleFieldChange}
+				onSubmit={handleSubmit}
+				summaryRef={summaryRef}
+			/>
+		</div>
+	);
+};
+
+export default CreateSteeringView;

--- a/webview-ui/src/features/create-steering-view/types.ts
+++ b/webview-ui/src/features/create-steering-view/types.ts
@@ -1,0 +1,37 @@
+export type CreateSteeringFormData = {
+	summary: string;
+	audience: string;
+	keyPractices: string;
+	antiPatterns: string;
+};
+
+export type CreateSteeringDraftState = {
+	formData: CreateSteeringFormData;
+	lastUpdated: number;
+};
+
+export type CreateSteeringInitPayload = {
+	shouldFocusPrimaryField: boolean;
+	draft?: CreateSteeringDraftState;
+};
+
+export type CreateSteeringExtensionMessage =
+	| { type: "create-steering/init"; payload: CreateSteeringInitPayload }
+	| { type: "create-steering/submit:success" }
+	| { type: "create-steering/submit:error"; payload: { message: string } }
+	| { type: "create-steering/confirm-close"; payload: { shouldClose: boolean } }
+	| { type: "create-steering/focus" };
+
+export type CreateSteeringFieldErrors = {
+	summary?: string;
+};
+
+export type CreateSteeringWebviewMessage =
+	| { type: "create-steering/submit"; payload: CreateSteeringFormData }
+	| { type: "create-steering/autosave"; payload: CreateSteeringFormData }
+	| {
+			type: "create-steering/close-attempt";
+			payload: { hasDirtyChanges: boolean };
+	  }
+	| { type: "create-steering/cancel" }
+	| { type: "create-steering/ready" };

--- a/webview-ui/src/page-registry.tsx
+++ b/webview-ui/src/page-registry.tsx
@@ -1,13 +1,19 @@
 import { CreateSpecView } from "./features/create-spec-view";
+import { CreateSteeringView } from "./features/create-steering-view";
 import { InteractiveView } from "./features/interactive-view";
 import { SimpleView } from "./features/simple-view";
 
-export type SupportedPage = "simple" | "interactive" | "create-spec";
+export type SupportedPage =
+	| "simple"
+	| "interactive"
+	| "create-spec"
+	| "create-steering";
 
 const pageRenderers = {
 	simple: () => <SimpleView />,
 	interactive: () => <InteractiveView />,
 	"create-spec": () => <CreateSpecView />,
+	"create-steering": () => <CreateSteeringView />,
 } satisfies Record<SupportedPage, () => JSX.Element>;
 
 export const getPageRenderer = (pageName: string) => {


### PR DESCRIPTION
## Title
Add custom steering creation dialog with autosave support

## Body

### Overview
Introduce a dedicated workflow for drafting custom steering guidance, including autosave and Codex prompt hand-off, plus supporting OpenSpec scaffolding.

### Changes
- Integrate a new `CreateSteeringInputController` and update `SteeringManager` to launch the dialog and handle persistence hooks.
- Add React-based webview UI for the Create Steering form with autosave, validation, and close-confirmation flows, along with accompanying types.
- Expand OpenSpec assets and prompts to cover custom steering creation and project context population.
- Update AGENTS contract documentation to reference OpenSpec instructions and register the new webview route.
- Add comprehensive unit tests for the controller and steering manager to exercise autosave, submit, and close scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive PR-draft workflow with staged prompts, previews, confirmations.
  * New Create Steering dialog: multi-field form, autosave/draft recovery, validation, submission, and close-confirmation.
  * UI/webview components and page entry for steering creation.

* **Tests**
  * Added tests covering steering dialog lifecycle, autosave, validation, submission, and integration flows.

* **Documentation**
  * New and expanded OpenSpec docs, AGENTS guidance, and project context documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->