### PR TITLE
feat(settings): Add command to open global config file

### DIFF
--- a/openspec/changes/add-settings-config-shortcut/proposal.md
+++ b/openspec/changes/add-settings-config-shortcut/proposal.md
@@ -1,0 +1,14 @@
+## Why
+- Updating Codex CLI settings requires editing the global `.codex/config.toml`, but the VS Code sidebar only links to workspace settings.
+- Users switching between projects need a direct shortcut to open the shared config without hunting for the hidden home directory path.
+- Aligning the extension with the CLI improves trust that Codex behavior matches the user's configured defaults.
+
+## What Changes
+- Add a `kiro-codex-ide.settings.openConfig` command that resolves the OS-specific path to the global `.codex/config.toml` and opens it in the editor, surfacing a notification if the file is missing.
+- Surface a new "Open Global Config (config.toml)" action in the Settings view welcome panel alongside the existing settings and help commands.
+- Share the home-directory resolution helper so the command covers Linux, macOS, and Windows paths consistently with other global Codex resources.
+
+## Impact
+- Gives Codex IDE users a single-click path to review or edit their global Codex configuration without leaving VS Code.
+- Encourages consistent configuration between the CLI and extension while avoiding accidental edits when the file is absent.
+- Adds one command and light UI copy changes with negligible performance or architectural risk.

--- a/openspec/changes/add-settings-config-shortcut/specs/settings/spec.md
+++ b/openspec/changes/add-settings-config-shortcut/specs/settings/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+### Requirement: Settings View Global Config Shortcut
+The Settings view MUST expose a command that opens the global Codex configuration file so users can review or edit `config.toml` without leaving VS Code.
+
+#### Scenario: Launch global config from Settings view
+- **GIVEN** the Kiro for Codex IDE extension is active and the user opens the Settings view
+- **WHEN** they invoke the "Open Global Config (config.toml)" action
+- **THEN** the extension opens the file located at the platform-specific global path (`~/.codex/config.toml` on Linux/macOS or `%USERPROFILE%\.codex\config.toml` on Windows) in an editor tab
+- **AND** it notifies the user if the file is missing so they know to create it manually.
+
+### Requirement: Resolve Global Config Path
+The extension MUST resolve the global Codex config path using the current user's home directory across supported platforms.
+
+#### Scenario: Resolve config path for each platform
+- **GIVEN** the user runs the extension on Linux, macOS, or Windows
+- **WHEN** the new settings command resolves the global config path
+- **THEN** it expands the user's home directory and joins `.codex/config.toml` using the platform's path separators before attempting to open the file.

--- a/openspec/changes/add-settings-config-shortcut/tasks.md
+++ b/openspec/changes/add-settings-config-shortcut/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+- [ ] 1.1 Add a shared utility that returns the absolute path to the global Codex config (`~/.codex/config.toml` or `%USERPROFILE%\.codex\config.toml`) and cover edge cases when the home directory is unavailable.
+- [ ] 1.2 Register the `kiro-codex-ide.settings.openConfig` command to open the resolved config path in the editor, showing a VS Code notification if the file cannot be found or read.
+- [ ] 1.3 Extend the Settings view welcome panel copy to include an "Open Global Config (config.toml)" entry and ensure the new command appears in package contributions and command palette metadata.
+- [ ] 1.4 Add unit coverage for the path helper and command behavior (success and missing-file scenarios) using existing mocking patterns for VS Code APIs.
+
+## 2. Validation
+- [ ] 2.1 Manually verify on one platform and stub tests for others that the command opens the config file when present and shows a descriptive error when absent.
+- [ ] 2.2 Run `npm run lint`, `npm run test`, and `npm run check` to confirm compliance with steering linting, formatting, and type expectations.

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
       },
       {
         "view": "kiro-codex-ide.views.overview",
-        "contents": "Configure Kiro for Codex IDE\n\n[$(gear) Open Settings](command:kiro-codex-ide.settings.open)\n[$(question) Help](command:kiro-codex-ide.help.open)"
+        "contents": "Configure Kiro for Codex IDE\n\n[$(gear) Open Settings](command:kiro-codex-ide.settings.open)\n[$(file-text) Open Global Config (config.toml)](command:kiro-codex-ide.settings.openGlobalConfig)\n[$(question) Help](command:kiro-codex-ide.help.open)"
       }
     ],
     "commands": [
@@ -232,6 +232,12 @@
         "icon": "$(gear)"
       },
       {
+        "command": "kiro-codex-ide.settings.openGlobalConfig",
+        "title": "Open Global Config (config.toml)",
+        "category": "Kiro for Codex IDE",
+        "icon": "$(file-text)"
+      },
+      {
         "command": "kiroCodex.help.open",
         "title": "Kiro Help",
         "category": "Kiro for Codex",
@@ -273,6 +279,11 @@
         {
           "command": "kiro-codex-ide.prompts.refresh",
           "when": "view == kiro-codex-ide.views.promptsExplorer",
+          "group": "navigation@2"
+        },
+        {
+          "command": "kiro-codex-ide.settings.openGlobalConfig",
+          "when": "view == kiro-codex-ide.views.overview",
           "group": "navigation@2"
         }
       ],
@@ -316,6 +327,9 @@
         {
           "command": "kiro-codex-ide.prompts.create",
           "when": "workspaceFolderCount > 0"
+        },
+        {
+          "command": "kiro-codex-ide.settings.openGlobalConfig"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { homedir } from "os";
+import { join } from "node:path";
 import type { FileSystemWatcher } from "vscode";
 import {
 	commands,
@@ -475,6 +476,43 @@ function registerCommands(
 				VSC_CONFIG_NAMESPACE
 			);
 		}),
+		commands.registerCommand(
+			"kiro-codex-ide.settings.openGlobalConfig",
+			async () => {
+				outputChannel.appendLine("Opening global Codex config...");
+				const userHome =
+					homedir() || process.env.HOME || process.env.USERPROFILE;
+
+				if (!userHome) {
+					window.showErrorMessage(
+						"Unable to resolve the user home directory for Codex config."
+					);
+					return;
+				}
+
+				const configUri = Uri.file(join(userHome, ".codex", "config.toml"));
+
+				try {
+					await workspace.fs.stat(configUri);
+				} catch {
+					window.showWarningMessage(
+						`Global Codex config not found at ${configUri.fsPath}. Create the file manually to customize Codex CLI.`
+					);
+					return;
+				}
+
+				try {
+					const document = await workspace.openTextDocument(configUri);
+					await window.showTextDocument(document, { preview: false });
+				} catch (error) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					window.showErrorMessage(
+						`Failed to open global Codex config: ${message}`
+					);
+				}
+			}
+		),
 
 		// biome-ignore lint/suspicious/useAwait: ignore
 		commands.registerCommand("kiro-codex-ide.help.open", async () => {


### PR DESCRIPTION
### Overview
This PR introduces a new command and a sidebar link to open the global `.codex/config.toml` file directly from the VS Code interface. This improves user experience by providing a quick way to access the global configuration.

### Changes
- Added a new command `kiro-codex-ide.settings.openGlobalConfig`.
- The command resolves the path to the global `config.toml` file for different operating systems.
- A new link "Open Global Config (config.toml)" is added to the Settings view.
- The extension now shows a warning if the config file doesn't exist.
- Updated `package.json` to include the new command and menu item.
- Added the command implementation in `src/extension.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open Global Config (config.toml)" action in the Settings view for quick access to your global Codex configuration file.
  * Displays a notification if the configuration file is missing.
  * Supports Linux, macOS, and Windows paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->